### PR TITLE
Bugfix: Check expired timers in one place inside the event loop

### DIFF
--- a/lib/eventkit/event_loop.rb
+++ b/lib/eventkit/event_loop.rb
@@ -41,16 +41,18 @@ module Eventkit
 
     def tick
       ready_read, ready_write, _ = IO.select(@read_handlers.keys, @write_handlers.keys, [], select_interval)
-      ready_read.each do |io|
+      ready_read.each { |io|
         @read_handlers.fetch(io).each { |handler| handler.call(io) }
-      end if ready_read
+      } if ready_read
 
-      ready_write.each do |io|
+      ready_write.each { |io|
         @write_handlers.fetch(io).each { |handler| handler.call(io) }
-      end if ready_write
+      } if ready_write
 
-      @timers.each { |timer| timer.handler.call if timer.expired? }
-      @timers = @timers.reject(&:expired?)
+      @timers.select(&:expired?).each { |timer|
+        timer.handler.call
+        @timers.delete(timer)
+      }
       nil
     end
 


### PR DESCRIPTION
We could have situations where we never executed a timer handler
because at the time of iteration a timer would not appear as expired,
but by the time of executing the next line of code a timer would now
be expired and as a result it was being removed from the collection.