### PR TITLE
Make sure we're able to restart the event loop after stopping

### DIFF
--- a/lib/eventkit/event_loop.rb
+++ b/lib/eventkit/event_loop.rb
@@ -25,7 +25,10 @@ module Eventkit
       end
 
       loop do
-        break if stopped?
+        if stop_scheduled?
+          @stopped = false
+          break
+        end
         tick
       end
     end
@@ -35,7 +38,7 @@ module Eventkit
       @started = false
     end
 
-    def stopped?
+    def stop_scheduled?
       @stopped
     end
 


### PR DESCRIPTION
The @stopped variable was not reset after stopping the event looop, and
so we were not really able to re-start the event loop after stopping it
once.

The new test is also more accurate as it registers a new handler after
stopping the event loop and waits for its execution in order to pass the
test.